### PR TITLE
Build fixes for cuda feature.

### DIFF
--- a/diffusion_rs_backend/build.rs
+++ b/diffusion_rs_backend/build.rs
@@ -21,7 +21,6 @@ fn main() {
             .arg("-U__CUDA_NO_HALF2_OPERATORS__")
             .arg("-U__CUDA_NO_BFLOAT16_CONVERSIONS__")
             .arg("--expt-relaxed-constexpr")
-            .arg("--expt-extended-lambda")
             .arg("--use_fast_math")
             .arg("--verbose");
 

--- a/diffusion_rs_backend/kernels/bitsandbytes/dequant.cu
+++ b/diffusion_rs_backend/kernels/bitsandbytes/dequant.cu
@@ -1,6 +1,5 @@
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_store.cuh>
-#include <cub/cub.cuh>
 #include <float.h>
 
 typedef enum DataType_t


### PR DESCRIPTION
Small fixes to allow build with cuda. See #35 .

On Fedora Linux,  `-fPIE` option for nvcc is needed also, because all binaries are compiled with `-fPIE` by default. Example:
```
CUDA_NVCC_FLAGS=-fPIE cargo install --path diffusion_rs_cli --features cuda
```
